### PR TITLE
chore(deps,security): bump guava 18.0 -> 30.0-jre

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,7 +80,7 @@ dependencies {
 
     // moved to the beginning to be the overrider
     //compile("org.ow2.asm:asm-debug-all:6.0")
-    compile("com.google.guava:guava:18.0")
+    compile("com.google.guava:guava:30.0-jre")
 
     compile("net.sf.opencsv:opencsv:2.3") // reading CSVs.. also used by SpecialSource
     compile("com.cloudbees:diff4j:1.1") // for difing and patching


### PR DESCRIPTION
fixing CVE-2018-10237 and CVE-2020-8908